### PR TITLE
fixed not accepting Simple card in the Response

### DIFF
--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -27,7 +27,7 @@ class Response {
 
 		return $this;
 	}
-        
+
         /**
          * Set up response with SSML.
          * @param string $ssml
@@ -37,7 +37,7 @@ class Response {
                 $this->outputSpeech = new OutputSpeech;
                 $this->outputSpeech->type = 'SSML';
                 $this->outputSpeech->ssml = $ssml;
-                
+
                 return $this;
         }
 
@@ -52,7 +52,7 @@ class Response {
 
 		return $this;
 	}
-        
+
         /**
          * Set up reprompt with given ssml
          * @param string $ssml
@@ -76,7 +76,7 @@ class Response {
 		$this->card = new Card;
 		$this->card->title = $title;
 		$this->card->content = $content;
-		
+
 		return $this;
 	}
 
@@ -100,7 +100,7 @@ class Response {
 
 		return $this;
 	}
-        
+
         /**
          * Add a session attribute that will be passed in every requests.
          * @param string $key
@@ -115,13 +115,14 @@ class Response {
          * @return type
          */
 	public function render() {
+        $cardObject = $this->card ? $this->card : $this->linkaccount;
+
 		return array(
 			'version' => $this->version,
 			'sessionAttributes' => $this->sessionAttributes,
 			'response' => array(
 				'outputSpeech' => $this->outputSpeech ? $this->outputSpeech->render() : null,
-				'card' => $this->card ? $this->card->render() : null,
-                'card' => $this->linkaccount ? $this->linkaccount->render() : null,
+				'card' => $cardObject ? $cardObject->render() : null,
 				'reprompt' => $this->reprompt ? $this->reprompt->render() : null,
 				'shouldEndSession' => $this->shouldEndSession ? true : false
 			)


### PR DESCRIPTION
By having 2 keys with the same name ('card'), the last one (link account card) was prevailing over the first one (simple card)